### PR TITLE
[Naitei] Elasticsearch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,53 +3,26 @@ git_source(:github){|repo| "https://github.com/#{repo}.git"}
 
 ruby "3.2.2"
 
-# Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
-gem "rails", "~> 7.0.5"
-
-# The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
-gem "sprockets-rails"
-
-# Use mysql as the database for Active Record
-gem "mysql2", "~> 0.5"
-
-# Use the Puma web server [https://github.com/puma/puma]
-gem "puma", "~> 5.0"
-
-# Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
+gem "bcrypt", "~> 3.1.7"
+gem "bootsnap", require: false
+gem "elasticsearch-model"
+gem "elasticsearch-persistence"
+gem "elasticsearch-rails"
+gem "image_processing", "~> 1.2"
 gem "importmap-rails"
-
-# Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
-gem "turbo-rails"
-
-# Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
-gem "stimulus-rails"
-
-# Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
-
-# Use Redis adapter to run Action Cable in production
-# gem "redis", "~> 4.0"
-
-# Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
-# gem "kredis"
-
-# Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html]
-# gem "bcrypt", "~> 3.1.7"
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem "kredis"
+gem "mysql2", "~> 0.5"
+gem "puma", "~> 5.0"
+gem "rails", "~> 7.0.5"
+gem "redis", "~> 4.0"
+gem "sassc-rails"
+gem "sprockets-rails"
+gem "stimulus-rails"
+gem "turbo-rails"
 gem "tzinfo-data", platforms: %i(mingw mswin x64_mingw jruby)
 
-# Reduces boot times through caching; required in config/boot.rb
-gem "bootsnap", require: false
-
-# Use Sass to process CSS
-# gem "sassc-rails"
-
-# Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html]
-# gem "image_processing", "~> 1.2"
-
 group :development, :test do
-  # See https://guides.rubyonrails.org/debugging_rails_applications.html
   gem "debug", platforms: %i(mri mingw x64_mingw)
   gem "rubocop", "~> 1.26", require: false
   gem "rubocop-checkstyle_formatter", require: false
@@ -57,7 +30,6 @@ group :development, :test do
 end
 
 group :development do
-  # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
@@ -68,7 +40,6 @@ group :development do
 end
 
 group :test do
-  # Use system testing [https://guides.rubyonrails.org/testing.html]
   gem "capybara"
   gem "selenium-webdriver"
   gem "webdrivers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     base64 (0.1.1)
+    bcrypt (3.1.20)
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
@@ -89,11 +90,41 @@ GEM
     debug (1.8.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
+    elastic-transport (8.3.5)
+      faraday (< 3)
+      multi_json
+    elasticsearch (8.15.0)
+      elastic-transport (~> 8.3)
+      elasticsearch-api (= 8.15.0)
+    elasticsearch-api (8.15.0)
+      multi_json
+    elasticsearch-model (8.0.0)
+      activesupport (> 3)
+      elasticsearch (~> 8)
+      hashie
+    elasticsearch-persistence (8.0.0)
+      activemodel (> 4)
+      activesupport (> 4)
+      elasticsearch (~> 8)
+      elasticsearch-model (= 8)
+      hashie
+    elasticsearch-rails (8.0.0)
     erubi (1.12.0)
+    faraday (2.12.0)
+      faraday-net_http (>= 2.0, < 3.4)
+      json
+      logger
+    faraday-net_http (3.3.0)
+      net-http
+    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    hashie (5.0.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    image_processing (1.13.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (1.2.1)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
@@ -104,7 +135,12 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.3)
+    kredis (1.7.0)
+      activemodel (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      redis (>= 4.2, < 6)
     language_server-protocol (3.17.0.3)
+    logger (1.6.1)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -116,10 +152,14 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.19.0)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     mysql2 (0.5.5)
+    net-http (0.4.1)
+      uri
     net-imap (0.3.7)
       date
       net-protocol
@@ -173,6 +213,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    redis (4.8.1)
     regexp_parser (2.8.1)
     reline (0.3.7)
       io-console (~> 0.5)
@@ -198,7 +239,18 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.2)
+      ffi (~> 1.12)
+      logger
     rubyzip (2.3.2)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -213,6 +265,7 @@ GEM
     stimulus-rails (1.2.2)
       railties (>= 6.0.0)
     thor (1.2.2)
+    tilt (2.4.0)
     timeout (0.4.0)
     turbo-rails (1.4.0)
       actionpack (>= 6.0.0)
@@ -221,6 +274,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
+    uri (0.13.1)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -242,17 +296,25 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   capybara
   debug
+  elasticsearch-model
+  elasticsearch-persistence
+  elasticsearch-rails
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
+  kredis
   mysql2 (~> 0.5)
   puma (~> 5.0)
   rails (~> 7.0.5)
+  redis (~> 4.0)
   rubocop (~> 1.26)
   rubocop-checkstyle_formatter
   rubocop-rails (~> 2.14.0)
+  sassc-rails
   selenium-webdriver
   sprockets-rails
   stimulus-rails
@@ -265,4 +327,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.13
+   2.5.20

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,0 +1,7 @@
+development: &default
+  host: "http://elasticsearch:9200"
+  log: true
+test:
+  host: "http://elasticsearch:9200"
+production:
+  host: "http://www.yourelasticindex:9200"

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,0 +1,10 @@
+config = {
+  transport_options: { request: { timeout: 5 } }
+}
+if File.exist?("config/elasticsearch.yml")
+  template = ERB.new(File.new("config/elasticsearch.yml").read)
+  processed = YAML.safe_load(template.result(binding))
+  config.merge!(processed[Rails.env].symbolize_keys)
+end
+
+Elasticsearch::Model.client = Elasticsearch::Client.new(config)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - "3000:3000"
     depends_on:
       - db
+      - elasticsearch
     environment:
       MYSQL_HOST: ${MYSQL_HOST}
       MYSQL_USER: ${MYSQL_USER}
@@ -28,8 +29,32 @@ services:
     networks:
       - myapp-network
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.monitoring.enabled=false
+      - xpack.graph.enabled=false
+      - xpack.watcher.enabled=false
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    networks:
+      - myapp-network
+
 networks:
   myapp-network:
 
 volumes:
   mysql-data:
+  esdata:


### PR DESCRIPTION
## Checklist tự review pull trước khi ready nhờ trainer review
- [x] Kiểm tra mỗi pull request 1 commit, nếu nhiều commit thì hãy gộp commit thành 1 rồi đẩy lại lên git
- [x] Trong các file của rails (đuôi .erb, .rb, .yml): sử dụng nháy " thay vì nháy '
- [x] Trong file javascript: sử dụng nháy ' thay vì "
- [x] Sử dụng thụt lề 2 space (setting lại vscode /sublime text nếu chưa cài đặt)
- [x] Cuối mỗi file kiểm tra có end line (khi đẩy lên git xem file change k bị lỗi tròn đỏ ở cuối file)
- [x] Mỗi dòng nếu quá dài, cần xuống dòng (maximum: 80 kí tự mỗi dòng)
- [x] Xóa các file được tự động sinh ra khi dùng các câu lệnh rails generate ... tạo ra nhưng k dùng đến, không có dòng code nào được viết trong đó (hay gặp nhất là các file helper)
- [x] Khi tạo mảng, nên tích cực sử dụng %w( ), %i() . Thay vì STATES = ['draft', 'open', 'closed'] có thể dùng STATES = %w(draft open closed)
- [x] Xem các lỗi hay gặp khi triển khai Rails tutorial tại https://docs.google.com/document/d/104Csp4-vamVos5DEbi372nLBEfmqhj7h1ENYO8ebjCo/edit
- [x] Tham khảo coding convention https://github.com/framgia/coding-standards/blob/master/vn/README.md

## WHAT (optional)

- Cài đặt Elasticsearch trong Rails dùng `docker compose`

## HOW

### Cài đặt Elasticsearch bằng docker compose

```ruby
# Gemfile

gem "elasticsearch-model"
gem "elasticsearch-persistence"
gem "elasticsearch-rails"
```

```yml
  elasticsearch:
    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
    environment:
      - cluster.name=docker-cluster
      - bootstrap.memory_lock=true
      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
      - discovery.type=single-node
      - xpack.security.enabled=false
      - xpack.monitoring.enabled=false
      - xpack.graph.enabled=false
      - xpack.watcher.enabled=false
    ulimits:
      memlock:
        soft: -1
        hard: -1
    volumes:
      - esdata:/usr/share/elasticsearch/data
    ports:
      - "9200:9200"
      - "9300:9300"
    networks:
      - myapp-network
```

- `cluster.name=docker-cluster`: Thiết lập tên cluster của Elasticsearch là docker-cluster. Tên này dùng để định danh cluster Elasticsearch khi có nhiều node tham gia.

- `bootstrap.memory_lock=true`: Dòng này giúp khóa bộ nhớ trong Elasticsearch để ngăn chặn việc swap (trao đổi bộ nhớ giữa RAM và ổ đĩa) vì việc swap sẽ làm giảm hiệu suất của Elasticsearch. Điều này hữu ích khi xử lý khối lượng lớn dữ liệu và đảm bảo ổn định hiệu suất.

- `ES_JAVA_OPTS=-Xms512m -Xmx512m`: Đây là tùy chọn Java Virtual Machine (JVM) cho Elasticsearch. -Xms512m và -Xmx512m cấu hình dung lượng RAM tối thiểu và tối đa mà Elasticsearch sẽ sử dụng là 512MB. Điều này có nghĩa là Elasticsearch sẽ cố gắng sử dụng 512MB RAM và không vượt quá giới hạn đó.

- `discovery.type=single-node`: Đây là thiết lập cho phép Elasticsearch hoạt động trong chế độ một node, phù hợp cho môi trường phát triển. Trong chế độ này, Elasticsearch bỏ qua việc tìm kiếm các node khác trong cluster.

- `xpack.security.enabled=false: X-Pack` là bộ plugin tích hợp với Elasticsearch, trong đó xpack.security là thành phần dùng để bảo mật (authentication, authorization). Cấu hình này tắt bảo mật, vì vậy không cần người dùng hoặc mật khẩu để truy cập Elasticsearch, phù hợp cho môi trường phát triển hoặc thử nghiệm.

- `xpack.monitoring.enabled=false`: X-Pack Monitoring cung cấp khả năng giám sát cluster Elasticsearch. Cấu hình này tắt tính năng giám sát.

- `xpack.graph.enabled=false`: Tắt tính năng graph, một tính năng của X-Pack để phân tích mối quan hệ giữa dữ liệu.

- `xpack.watcher.enabled=false`: Tắt tính năng watcher, dùng để thiết lập cảnh báo dựa trên các sự kiện cụ thể trong Elasticsearch.

- `ulimits`: Thiết lập giới hạn tài nguyên hệ thống cho container Docker. Trong trường hợp này, memlock cấu hình khả năng khóa bộ nhớ.

- `soft: -1` và `hard: -1`: Điều này có nghĩa là không giới hạn khả năng khóa bộ nhớ (không có giới hạn mềm và giới hạn cứng). Điều này hỗ trợ tính năng khóa bộ nhớ (bootstrap.memory_lock) đã được bật trong biến môi trường phía trên.

> Nguồn: [Docker, Elasticsearch and Rails tutorial](https://medium.com/@diegoy_kuri/docker-elasticsearch-and-rails-tutorial-a78c0f116cef)

```ruby
# config/initializer/elasticsearch.rb

config = {
  transport_options: { request: { timeout: 5 } }
}
if File.exist?("config/elasticsearch.yml")
  template = ERB.new(File.new("config/elasticsearch.yml").read)
  processed = YAML.safe_load(template.result(binding))
  config.merge!(processed[Rails.env].symbolize_keys)
end

# if you choose to use elasticsearch-rails-model
Elasticsearch::Model.client = Elasticsearch::Client.new(config)
# if you choose to use elasticsearch-rails-persistence
Elasticsearch::Persistence.client = Elasticsearch::Client.new(config)
```

```ruby
# config/elasticsearch.yml

development: &default
  host: "http://elasticsearch:9200"
  log: true
test:
  host: "http://elasticsearch:9200"
production:
  host: "http://www.yourelasticindex:9200"
```

### Kiểm tra kết nối

Dùng lệnh:

```sh
sudo docker compose exec web bash
curl -X GET http://elasticsearch:9200
```

Kết quả sẽ có dạng:

```sh
{
  "name" : "c31872f8dd23",
  "cluster_name" : "docker-cluster",
  "cluster_uuid" : "kuV6wYWkTVm75QPGjRGqZg",
  "version" : {
    "number" : "7.10.2",
    "build_flavor" : "default",
    "build_type" : "docker",
    "build_hash" : "747e1cc71def077253878a59143c1f785afa92b9",
    "build_date" : "2021-01-13T00:42:12.435326Z",
    "build_snapshot" : false,
    "lucene_version" : "8.7.0",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  },
  "tagline" : "You Know, for Search"
}
```
## WHY (optional)

## Evidence (Screenshot or Video)

![image](https://github.com/user-attachments/assets/53aab56d-d4ab-4850-b41f-dbe7fe1ea674)

## Notes (Kiến thức tìm hiểu thêm)